### PR TITLE
Add Support for Mustache Templates

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -7,6 +7,7 @@ import (
 
 func init() {
 	// Set some env vars to test against
+	os.Setenv("RDCT_DEFAULT_TPL_ENGINE", "mustache")
 	os.Setenv("RDCT_DEFAULT_TPL_PATH", "/path/to/template")
 	os.Setenv("RDCT_DEFAULT_CFG_PATH", "/path/to/config")
 	os.Setenv("test_app_var", "test")
@@ -83,8 +84,38 @@ func TestEnvToMapFilterPrefix(t *testing.T) {
 	if _, ok := envs["RDCT_DEFAULT_CFG_PATH"]; !ok {
 		t.Error("could not find RDCT_DEFAULT_CFG_PATH in env map")
 	}
-	if len(envs) != 2 {
-		t.Error("expected only 2 vars, got ", len(envs))
+	if len(envs) != 3 {
+		t.Error("expected only 3 vars, got: ", len(envs))
+	}
+}
+
+func TestEnvResolveTplEngine(t *testing.T) {
+	envInstance = nil
+	eng := GetEnvInstance().ResolveTplEngine()
+	if eng != "mustache" {
+		t.Error("expected engine to be mustache, got: ", eng)
+	}
+	os.Setenv("RDCT_TPL_ENGINE", "go")
+	defer os.Unsetenv("RDCT_TPL_ENGINE")
+	envInstance = nil
+	eng = GetEnvInstance().ResolveTplEngine()
+	if eng != "go" {
+		t.Error("expected engine to be go, got: ", eng)
+	}
+}
+
+func TestEnvResolveTplEngineDefault(t *testing.T) {
+	envInstance = nil
+	eng := GetEnvInstance().ResolveTplEngineDefault("go")
+	if eng != "go" {
+		t.Error("expected path to be go, got: ", eng)
+	}
+	os.Setenv("RDCT_TPL_ENGINE", "mustache")
+	defer os.Unsetenv("RDCT_TPL_ENGINE")
+	envInstance = nil
+	eng = GetEnvInstance().ResolveCfgPathDefault("go")
+	if eng != "go" {
+		t.Error("expected path to be go, got: ", eng)
 	}
 }
 
@@ -92,14 +123,14 @@ func TestEnvResolveTplPath(t *testing.T) {
 	envInstance = nil
 	path := GetEnvInstance().ResolveTplPath()
 	if path != "/path/to/template" {
-		t.Error("expected path to be /path/to/template, got ", path)
+		t.Error("expected path to be /path/to/template, got: ", path)
 	}
 	os.Setenv("RDCT_TPL_PATH", "/path/to/override/template")
 	defer os.Unsetenv("RDCT_TPL_PATH")
 	envInstance = nil
 	path = GetEnvInstance().ResolveTplPath()
 	if path != "/path/to/override/template" {
-		t.Error("expected path to be /path/to/override/template, got ", path)
+		t.Error("expected path to be /path/to/override/template, got: ", path)
 	}
 }
 
@@ -107,14 +138,14 @@ func TestResolveTplPathDefault(t *testing.T) {
 	envInstance = nil
 	path := GetEnvInstance().ResolveTplPathDefault("/path/to/template")
 	if path != "/path/to/template" {
-		t.Error("expected path to be /path/to/template, got ", path)
+		t.Error("expected path to be /path/to/template, got: ", path)
 	}
 	os.Setenv("RDCT_TPL_PATH", "/path/to/override/template")
 	defer os.Unsetenv("RDCT_TPL_PATH")
 	envInstance = nil
 	path = GetEnvInstance().ResolveTplPathDefault("/path/to/template")
 	if path != "/path/to/override/template" {
-		t.Error("expected path to be /path/to/override/template, got ", path)
+		t.Error("expected path to be /path/to/override/template, got: ", path)
 	}
 }
 
@@ -122,14 +153,14 @@ func TestEnvResolveCfgPath(t *testing.T) {
 	envInstance = nil
 	path := GetEnvInstance().ResolveCfgPath()
 	if path != "/path/to/config" {
-		t.Error("expected path to be /path/to/config, got ", path)
+		t.Error("expected path to be /path/to/config, got: ", path)
 	}
 	os.Setenv("RDCT_CFG_PATH", "/path/to/override/config")
 	defer os.Unsetenv("RDCT_CFG_PATH")
 	envInstance = nil
 	path = GetEnvInstance().ResolveCfgPath()
 	if path != "/path/to/override/config" {
-		t.Error("expected path to be /path/to/override/config, got ", path)
+		t.Error("expected path to be /path/to/override/config, got: ", path)
 	}
 }
 
@@ -137,13 +168,13 @@ func TestResolveCfgPathDefault(t *testing.T) {
 	envInstance = nil
 	path := GetEnvInstance().ResolveCfgPathDefault("/path/to/config")
 	if path != "/path/to/config" {
-		t.Error("expected path to be /path/to/config, got ", path)
+		t.Error("expected path to be /path/to/config, got: ", path)
 	}
 	os.Setenv("RDCT_CFG_PATH", "/path/to/override/config")
 	defer os.Unsetenv("RDCT_CFG_PATH")
 	envInstance = nil
 	path = GetEnvInstance().ResolveCfgPathDefault("/path/to/config")
 	if path != "/path/to/override/config" {
-		t.Error("expected path to be /path/to/override/config, got ", path)
+		t.Error("expected path to be /path/to/override/config, got: ", path)
 	}
 }

--- a/service.go
+++ b/service.go
@@ -35,27 +35,34 @@ func PreRenderScriptEnv(scriptPath string) (map[string]string, error) {
 }
 
 // RenderCfgStdOut renders a configuration to stdout using the service config
-func RenderCfgStdOut(tplPath string) error {
-	return RenderCfg(tplPath, os.Stdout)
+func RenderCfgStdOut(tplPath, engine string) error {
+	return RenderCfg(tplPath, engine, os.Stdout)
 }
 
 // RenderCfgFile renders a configuration to a file using the service config
-func RenderCfgFile(tplPath, cfgPath string) error {
+func RenderCfgFile(tplPath, cfgPath, engine string) error {
 	f, err := os.Create(cfgPath)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	// use buffered writer to mitigate partially
-	// written files on rendering error
+	// use buffered writer to prevent partially written files on error
 	w := bufio.NewWriterSize(f, WriteBufferSize)
-	defer w.Flush()
-	return RenderCfg(tplPath, w)
+	if err = RenderCfg(tplPath, engine, w); err != nil {
+		return err
+	}
+	w.Flush()
+	return nil
 }
 
 // RenderCfgFile renders a configuration to any io.Writer
-func RenderCfg(tplPath string, w io.Writer) error {
-	return template.New(tplPath, GetEnvInstance().ToMap()).Render(w)
+func RenderCfg(tplPath, engine string, w io.Writer) error {
+	vars := GetEnvInstance().ToMap()
+	eng, err := template.EngineFactory(engine)
+	if err != nil {
+		return err
+	}
+	return template.New(tplPath, vars, eng).Render(w)
 }
 
 // ExecGosu executes a command with a specific userspec using libgosu

--- a/service_test.go
+++ b/service_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	tplPath             = "test/test.redacted"
+	tplPathGo           = "test/test.redacted"
+	tplPathMustache     = "test/test.mustache"
 	preRenderScriptPath = "test/pre-render.sh"
 )
 
@@ -15,14 +16,25 @@ func init() {
 	os.Setenv("test_app_var", "test")
 }
 
-func TestRenderCfg(t *testing.T) {
+func TestRenderCfgGoEngine(t *testing.T) {
 	var rendered = new(bytes.Buffer)
-	err := RenderCfg(tplPath, rendered)
+	err := RenderCfg(tplPathGo, "go", rendered)
 	if err != nil {
 		t.Error(err)
 	}
-	if rendered.String() != "test=test" {
-		t.Error("Expected \"test=test\", got ", rendered.String())
+	if rendered.String() != "test=test\n" {
+		t.Error("Expected \"test=test\", got: ", rendered.String())
+	}
+}
+
+func TestRenderCfgMustacheEngine(t *testing.T) {
+	var rendered = new(bytes.Buffer)
+	err := RenderCfg(tplPathMustache, "mustache", rendered)
+	if err != nil {
+		t.Error(err)
+	}
+	if rendered.String() != "test=test\n" {
+		t.Error("Expected \"test=test\", got: ", rendered.String()[9])
 	}
 }
 

--- a/template/engine.go
+++ b/template/engine.go
@@ -1,8 +1,17 @@
 package template
 
 import (
+	"errors"
 	"io"
 	"text/template"
+
+	"github.com/cbroglie/mustache"
+)
+
+// template engine type string names
+const (
+	EngineTypeGo       = "go"
+	EngineTypeMustache = "mustache"
 )
 
 // Engine template engine interface
@@ -10,17 +19,24 @@ type Engine interface {
 	Render(tpl *Template, w io.Writer) error
 }
 
+// EngineFactory returns an engine ptr based on the string name of the engine
+func EngineFactory(name string) (Engine, error) {
+	switch name {
+	case EngineTypeGo:
+		return &GoEngine{}, nil
+	case EngineTypeMustache:
+		return &MustacheEngine{}, nil
+	default:
+		return nil, errors.New("invalid template engine: " + name)
+	}
+}
+
 // GoEngine go based template engine
 type GoEngine struct {
 }
 
-// NewGoEngine constructor
-func NewGoEngine() *GoEngine {
-	return &GoEngine{}
-}
-
-// Render renders template data from the io.Reader stream to the
-// io.Writer stream
+// Render implements the Engine interface and renders template data
+// from the io.Reader stream to the io.Writer stream
 func (g *GoEngine) Render(tpl *Template, w io.Writer) error {
 	tplData, err := tpl.ReadAllToString()
 	if err != nil {
@@ -31,6 +47,28 @@ func (g *GoEngine) Render(tpl *Template, w io.Writer) error {
 		return err
 	}
 	err = t.Execute(w, tpl.Vars())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MustacheEngine mustache template engine
+type MustacheEngine struct {
+}
+
+// Render implements the Engine interface and renders template data
+// from the io.Reader stream to the io.Writer stream
+func (m *MustacheEngine) Render(tpl *Template, w io.Writer) error {
+	tplData, err := tpl.ReadAllToString()
+	if err != nil {
+		return err
+	}
+	r, err := mustache.Render(tplData, tpl.Vars())
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte(r))
 	if err != nil {
 		return err
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -15,8 +15,7 @@ type Template struct {
 }
 
 // New creates a new template
-func New(path string, vars map[string]string) *Template {
-	engine := NewGoEngine()
+func New(path string, vars map[string]string, engine Engine) *Template {
 	return &Template{path: path, vars: vars, engine: engine}
 }
 

--- a/test/test.mustache
+++ b/test/test.mustache
@@ -1,0 +1,1 @@
+{{#test_app_var}}test={{test_app_var}}{{/test_app_var}}

--- a/test/test.redacted
+++ b/test/test.redacted
@@ -1,1 +1,1 @@
-{{if .test_app_var}}test={{.test_app_var}}{{end -}}
+{{if .test_app_var}}test={{.test_app_var}}{{end}}


### PR DESCRIPTION
Resolves #2 
Uses http://github.com/cbroglie/mustache mustache implementation
Added cli flags to specify the default template engine to use
Added env config support for specifying the template engine
Added mustache template tests
Updated user guide (README) with template engine usage basics