### PR TITLE
Fix version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build: pull
 				&& cd $(BIN) && go get -d && cd .. \
 				&& CGO_ENABLED=0 go test \
 				&& cd $(BIN) \
-				&& GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags "-s -w -X redact.Version=$(VERSION)" -v'
+				&& GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=$(VERSION)" -v'
 
 shell: pull
 	@docker run --rm -ti --init \

--- a/redact/cmd.go
+++ b/redact/cmd.go
@@ -26,6 +26,9 @@ Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
 Use "{{.CommandPath}} COMMAND --help" for more information about a command.{{end}}
 `
 
+var versionString = fmt.Sprintf("redact version %s %s %s %s",
+	version, runtime.GOOS, runtime.GOARCH, runtime.Compiler)
+
 // global flags
 var globalQuiet bool
 
@@ -177,6 +180,7 @@ Example: redact entrypoint -- nobody id
          redact entrypoint -- nobody:root id`,
 	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		log.Print(versionString)
 		var env = redact.GetEnvInstance()
 		// handle pre-render script
 		if err = handlePreRenderScript(cmd); err != nil {
@@ -236,7 +240,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Printf("redact version %s %s %s %s", redact.Version, runtime.GOOS,
-			runtime.GOARCH, runtime.Compiler)
+		log.Print(versionString)
 	},
 }

--- a/redact/main.go
+++ b/redact/main.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 )
 
+var version = "dev"
+
 func init() {
 	runtime.GOMAXPROCS(1)
 	runtime.LockOSThread()

--- a/version.go
+++ b/version.go
@@ -1,4 +1,0 @@
-package redact
-
-// Version redact core version
-var Version = "dev"


### PR DESCRIPTION
Fixed issue with redact version variable not being populated at
build/release time
The version string is now the first output from the entrypoint
command